### PR TITLE
VS restart seems to be required

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ Did you encounter a WebSharper bug while working on your project, and want to im
         </configuration>
         ```
         
-    * Update the NuGet packages either from Visual Studio's GUI, or with the command line:
+    * Update the NuGet packages either from Visual Studio's GUI (a restart may be required), or with the command line:
     
         ```sh
         dotnet add WebSharper


### PR DESCRIPTION
After upgrading WebSharper nuget packages a reboot seems to be required on Windows 11 with Visual Studio 2022

Steps to reproduce:
- dotnet new websharper-spa -lang f# -n MySPA
- This application have some issue that I will try to fix by changing WebSharper.core
- On my local WebSharper.core, I increment the version tag (I'm not sure if this is needed), make some modifications, and run the tests. When it's ok, I do a "build.cmd ws-package"
- Update nuget packages on VS Gui, then "dotnet clean, dotnet run"
- The MySpa issue persists.
- I try: dotnet ws-stop, dotnet clean, dotnet run
- The MySpa issue persists.
- Restart Visual Studio 2022, dotnet clean, dotnet run, the issue is fixed.